### PR TITLE
Fix subtle potential bug in actor destruction

### DIFF
--- a/libcaf_core/caf/local_actor.hpp
+++ b/libcaf_core/caf/local_actor.hpp
@@ -199,8 +199,7 @@ public:
 
   /// Returns the hosting actor system.
   inline actor_system& system() const {
-    CAF_ASSERT(context_);
-    return context_->system();
+    return home_system();
   }
 
   /// Returns the config of the hosting actor system.


### PR DESCRIPTION
Actors that access the actor system in their cleanup code code, e.g., in
the state destructor of stateful actors, can access an invalid context.
Always accessing the home system instead of retrieving it from the
context fixes this subtle bug.